### PR TITLE
fix: Added terminate command to drop open connections

### DIFF
--- a/commands/create_db
+++ b/commands/create_db
@@ -13,6 +13,10 @@ Point it to the database to create from with the DB_ env variables."
 : ${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}
 DB_TEMPLATE=${DB_TEMPLATE:-template1}
 
+# Fixes errors where connections are left open to the template
+echo Dropping connections to database $DB_NAME on host $DB_HOST
+PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
+
 echo Creating database $DB_NAME on host $DB_HOST from template $DB_TEMPLATE as user $DB_USER
 PGPASSWORD="$DB_PASS" createdb -U $DB_USER -h $DB_HOST -T $DB_TEMPLATE $DB_NAME
 

--- a/commands/create_db
+++ b/commands/create_db
@@ -14,8 +14,8 @@ Point it to the database to create from with the DB_ env variables."
 DB_TEMPLATE=${DB_TEMPLATE:-template1}
 
 # Fixes errors where connections are left open to the template
-echo Dropping connections to database $DB_NAME on host $DB_HOST
-PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
+echo Dropping connections to database $DB_TEMPLATE on host $DB_HOST as user $DB_USER
+PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_TEMPLATE -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
 
 echo Creating database $DB_NAME on host $DB_HOST from template $DB_TEMPLATE as user $DB_USER
 PGPASSWORD="$DB_PASS" createdb -U $DB_USER -h $DB_HOST -T $DB_TEMPLATE $DB_NAME

--- a/commands/drop_db
+++ b/commands/drop_db
@@ -13,7 +13,7 @@ Point it to the database to drop from with the DB_ env variables."
 : ${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}
 
 # Fixes errors where connections are left open to the database
-echo Dropping connections to database $DB_NAME on host $DB_HOST
+echo Dropping connections to database $DB_NAME on host $DB_HOST as user $DB_USER
 PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
 
 #if PGPASSWORD="$DB_PASS" psql -lqtA -U $DB_USER -h $DB_HOST | grep -q "^$DB_NAME|";then

--- a/commands/drop_db
+++ b/commands/drop_db
@@ -12,6 +12,10 @@ Point it to the database to drop from with the DB_ env variables."
 : ${DB_USER?You must provide an DB_USER as an enviornment variable. "$USAGE"}
 : ${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}
 
+# Fixes errors where connections are left open to the database
+echo Dropping connections to database $DB_NAME on host $DB_HOST
+PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
+
 #if PGPASSWORD="$DB_PASS" psql -lqtA -U $DB_USER -h $DB_HOST | grep -q "^$DB_NAME|";then
   echo Dropping database $DB_NAME on host $DB_HOST as user $DB_USER
   PGPASSWORD="$DB_PASS" dropdb -U $DB_USER -h $DB_HOST $DB_NAME

--- a/commands/restore_db
+++ b/commands/restore_db
@@ -14,6 +14,10 @@ Point it to the server to restore to with the DB_ env variables."
 : ${DB_USER?You must provide an DB_USER as an enviornment variable. "$USAGE"}
 : ${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}
 
+# Fixes errors where connections are left open to the database
+echo Dropping connections to database $DB_NAME on host $DB_HOST
+PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
+
 echo Restoring database $DB_NAME on host $DB_HOST as user $DB_USER from backup $BACKUP_DUMP
 PGPASSWORD="$DB_PASS" pg_restore -U $DB_USER  -h $DB_HOST --no-owner --no-privileges --role=$DB_USER -d $DB_NAME /srv/postgres/backups/$BACKUP_DUMP
 

--- a/commands/restore_db
+++ b/commands/restore_db
@@ -15,7 +15,7 @@ Point it to the server to restore to with the DB_ env variables."
 : ${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}
 
 # Fixes errors where connections are left open to the database
-echo Dropping connections to database $DB_NAME on host $DB_HOST
+echo Dropping connections to database $DB_NAME on host $DB_HOST as user $DB_USER
 PGPASSWORD="$DB_PASS" psql -P pager=off -d $DB_NAME -U $DB_USER -h $DB_HOST -c 'SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();'
 
 echo Restoring database $DB_NAME on host $DB_HOST as user $DB_USER from backup $BACKUP_DUMP


### PR DESCRIPTION
The nightly restore kept erroring out with open connections.
This fix drops open connections.