### PR TITLE
Pin Alpine to 3.18 and PostgreSQL to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine
-RUN apk --update add bash postgresql postgresql-client && rm -rf /var/cache/apk/*
+FROM alpine:3.18
+RUN apk --update add bash postgresql14 postgresql14-client && \
+    rm -rf /var/cache/apk/*
 COPY commands .
 
 


### PR DESCRIPTION
This matches our production database version (at least in major version) so should cause fewer issues with database dumps.

I tested that the image can be built locally.