### PR TITLE
Back up AAA data alongside full database dump

### DIFF
--- a/commands/backup_db
+++ b/commands/backup_db
@@ -17,3 +17,19 @@ BACKUP_DUMP=${BACKUP_DUMP:-$BACKUP_DB_NAME.dump}
 
 echo Backing up database $BACKUP_DB_NAME on host $BACKUP_DB_HOST as user $BACKUP_DB_USER to file $BACKUP_DUMP
 PGPASSWORD="$BACKUP_DB_PASS" pg_dump -d $BACKUP_DB_NAME -U $BACKUP_DB_USER -h $BACKUP_DB_HOST -W --clean -F c -Z 9 -f /srv/postgres/backups/$BACKUP_DUMP
+
+echo "Backing up critical AAA data to aaa.dump..."
+PGPASSWORD="$BACKUP_DB_PASS" pg_dump \
+	--dbname="$BACKUP_DB_NAME" \
+	--username="$BACKUP_DB_USER" \
+	--host="$BACKUP_DB_HOST" \
+	--password \
+	--clean \
+	--format=c \
+	--compress=9 \
+	--table=aaa_identity_type_policies \
+	--table=aaa_identity_types \
+	--table=aaa_permissions \
+	--table=aaa_policies \
+	--table=aaa_policy_permissions \
+	--file="/srv/postgres/backups/aaa.dump"

--- a/commands/import_data
+++ b/commands/import_data
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+USAGE="
+
+This script imports data from a partial database dump (created via pg_dump).
+Objects are dropped first (if they exist) before being imported.
+Point it to the backup to restore from with the \$DUMP_FILE env variable.
+Point it to the server to restore to with the DB_ env variables."
+
+: "${DUMP_FILE?You must provide an DUMP_FILE as an enviornment variable. "$USAGE"}"
+: "${DB_HOST?You must provide an DB_HOST as an enviornment variable. "$USAGE"}"
+: "${DB_NAME?You must provide an DB_NAME as an enviornment variable. "$USAGE"}"
+: "${DB_USER?You must provide an DB_USER as an enviornment variable. "$USAGE"}"
+: "${DB_PASS?You must provide an DB_PASS as an enviornment variable. "$USAGE"}"
+
+echo "Importing $DUMP_FILE into database $DB_NAME on host $DB_HOST as user $DB_USER..."
+PGPASSWORD="$DB_PASS" pg_restore \
+	--username="$DB_USER" \
+	--host="$DB_HOST" \
+	--no-owner \
+	--no-privileges \
+	--role="$DB_USER" \
+	--dbname="$DB_NAME" \
+	--clean \
+	--if-exists \
+	"/srv/postgres/backups/$DUMP_FILE"


### PR DESCRIPTION
This gives us a shorter path to maintaining parity for authorization between production and development/test/staging – the small AAA dump can be imported into a seeded database instead of importing the full production dump.